### PR TITLE
fix: remove extra escape character in guide

### DIFF
--- a/docs/source/developer_guide/register_custom_fusion.rst
+++ b/docs/source/developer_guide/register_custom_fusion.rst
@@ -133,7 +133,7 @@ It provide 4 methods for the fusion.
     .. code-block:: python
         :linenos:
 
-        with model.graph.inserting_after(node_to_replace)\:
+        with model.graph.inserting_after(node_to_replace):
             new_node = model.graph.create_node(
                 op=...,
                 target=...,


### PR DESCRIPTION
tutorial 里似乎有个小问题