### PR TITLE
Rewrite calibration

### DIFF
--- a/sparsebit/quantization/tools/__init__.py
+++ b/sparsebit/quantization/tools/__init__.py
@@ -1,3 +1,4 @@
 from .errors_profiler import QuantizationErrorProfiler, SharedData
 from .graph_wrapper import fx_symbolic_trace
+from .tensor_wrapper import to_detach, to_cpu
 from .calibration import *

--- a/sparsebit/quantization/tools/calibration.py
+++ b/sparsebit/quantization/tools/calibration.py
@@ -88,6 +88,9 @@ class CalibrationRunner(object):
             with torch.no_grad():
                 outputs = []
                 for batch_idx in range(batch_num):
+                    if node.op == "get_attr":  # is constant value
+                        outputs.append(to_cpu(module.data))
+                        continue
                     batch = self.builder.storage.extract_node_args(
                         node.args, batch=batch_idx
                     )
@@ -99,6 +102,6 @@ class CalibrationRunner(object):
 
     def weight_calibration(self):
         for n, m in self.model.named_modules():
-            if isinstance(m, QuantOpr) and m.weight_quantizer:
+            if isinstance(m, QuantOpr) and getattr(m, "weight_quantizer", None):
                 m.weight_quantizer.update_observer(m.weight)
                 m.weight_quantizer.calc_qparams()

--- a/sparsebit/quantization/tools/calibration.py
+++ b/sparsebit/quantization/tools/calibration.py
@@ -2,88 +2,103 @@ import torch
 from functools import partial
 
 from sparsebit.quantization.modules import QuantOpr
-from sparsebit.quantization.tools import SharedData
+from .graph_wrapper import GraphVisisor, fx_symbolic_trace
+from .tensor_wrapper import to_cpu, to_device, to_detach
 
 
-def get_topo(model):
-    calib_cache = SharedData()
-    for node in model.graph.nodes:
-        if node.op in ["output"]:  # skip output empty node
-            continue
-        node_name = node.name
+class CalibrationRunner(object):
+    def __init__(self, model):
+        self.model = fx_symbolic_trace(model)
 
-        # 输入module名称，None表示不是module，此时没有量化，可以直接使用float输入值作为量化输入值。
-        input_node_names = []
-        for input_node in node.args:
-            if not isinstance(input_node, torch.fx.node.Node) or input_node.op in [
-                "output",
-            ]:
-                input_node_names.append(None)
-            else:
-                input_node_names.append(input_node.name)
-        calib_cache.add_node(node_name, input_node_names)
-    return calib_cache
-
-
-def register_hook(model, calib_cache):
-    def _forward_hook(module, x_in, x_out, name):
-        prev_data = calib_cache.get_value(name)
-        if prev_data is None:
-            prev_data = []
-        assert isinstance(
-            prev_data, list
-        ), "calibration data must be cached in list format!"
-        prev_data.append(x_in[0].cpu())
-        calib_cache.set_value(name, prev_data)
-
-    calibration_handles = []
-    for node in model.graph.nodes:
-        if node.op == "placeholder":
-            for n in node.users:
-                module = getattr(model, n.target)
-                quant_node = n
-                while not (isinstance(module, QuantOpr) and module.input_quantizer):
-                    quant_node = n.next
-                    module = getattr(model, quant_node.target)
-
-                assert (
-                    len(module._forward_hooks) == 0
-                ), "only support one input in calibration now"
-
-                h = module.register_forward_hook(
-                    hook=partial(_forward_hook, name=quant_node.prev.name)
-                )
-                calibration_handles.append(h)
-    return calibration_handles
-
-
-def feature_layerwise_calibration(model, calib_cache, device):
-    for node in model.graph.nodes:
-        if (
-            node.op in ["placeholder", "output"]
-            or calib_cache.get_value(node.prev.name) is None
-        ):
-            continue
-        module = getattr(model, node.target)
-        if isinstance(module, QuantOpr) and module.input_quantizer:
-            for x in calib_cache.get_value(node.prev.name):
-                module.input_quantizer.update_observer(x)
-            module.input_quantizer.calc_qparams()
-            module.input_quantizer.observer.reset_data_cache()
-        inputs = zip(
-            *[
-                calib_cache.get_value(node.all_input_nodes[i].name)
-                for i in range(len(node.all_input_nodes))
-            ]
+    def prepare_calibration(self):
+        record_input_names = set(
+            i.target for i in self.model.graph.nodes if i.op == "placeholder"
         )
-        with torch.no_grad():
-            outputs = []
-            for batch in inputs:
-                batch = [input.to(device) for input in batch]
-                outputs.append(module(*batch).cpu())
-        calib_cache.set_value(node.name, outputs)
-        calib_cache.finish_node(node.name)
 
-    assert len(calib_cache.outputs) == 0
-    assert len(calib_cache.output_degrees) == 0
-    del calib_cache
+        # tile outputs in input nodes
+        def _forward_hook(module, x_in, x_out, node, storage, record_names):
+            def flatten(x):
+                if isinstance(x, (list, tuple)):
+                    out = []
+                    for i in x:
+                        out.extend(flatten(i))
+                    return tuple(out)
+                return (x,)
+
+            pos = 0
+            flatten_x_in = flatten(x_in)
+            flatten_args = flatten(node.args)
+            for _x_in, _args in zip(flatten_x_in, flatten_args):
+                if isinstance(_args, torch.fx.Node) and _args.target in record_names:
+                    input_name = _args.target
+                    datas = storage.get_output(input_name)
+                    if datas is None:
+                        datas = []
+                    datas.append(to_cpu(to_detach(x_in[pos])))
+                    storage.set_output(input_name, datas)
+
+        def hook_wrapper(node, module, storage):
+            hooks = []
+            input_names_to_record = [
+                inp_node.target
+                for inp_node in node.all_input_nodes
+                if inp_node.target in record_input_names
+            ]
+            if len(input_names_to_record) > 0:
+                hooks.append(
+                    module.register_forward_hook(
+                        hook=partial(
+                            _forward_hook,
+                            node=node,
+                            storage=storage,
+                            record_names=input_names_to_record,
+                        )
+                    )
+                )
+                for input_name_to_record in input_names_to_record:
+                    record_input_names.remove(input_name_to_record)
+
+            return hooks
+
+        self.builder = GraphVisisor(self.model, hook_wrapper)
+
+    def feature_layerwise_calibration(self, device):
+        # manual forward once to calculate calibration
+        assert hasattr(self, "builder"), "run self.prepare_calibration first!"
+        batch_num = None
+        for node in self.model.graph.nodes:
+            if node.op in ["placeholder", "output"]:
+                if batch_num is None:
+                    batch_num = len(self.builder.storage.get_output(node.target))
+                continue
+
+            assert batch_num is not None
+
+            module = getattr(self.model, node.target)
+            if isinstance(module, QuantOpr) and getattr(
+                module, "input_quantizer", None
+            ):
+                for inp_node in node.all_input_nodes:
+                    inp_tensors = self.builder.storage.get_output(inp_node.target)
+                    for inp_tensor in inp_tensors:
+                        module.input_quantizer.update_observer(inp_tensor)
+                module.input_quantizer.calc_qparams()
+                module.input_quantizer.observer.reset_data_cache()
+
+            with torch.no_grad():
+                outputs = []
+                for batch_idx in range(batch_num):
+                    batch = self.builder.storage.extract_node_args(
+                        node.args, batch=batch_idx
+                    )
+                    # more time for less cuda memory occupation
+                    batch = [to_device(input, device) for input in batch]
+                    outputs.append(to_cpu(module(*batch, **node.kwargs)))
+            self.builder.storage.set_output(node.target, outputs)
+            self.builder.storage.finish_node(node.target)
+
+    def weight_calibration(self):
+        for n, m in self.model.named_modules():
+            if isinstance(m, QuantOpr) and m.weight_quantizer:
+                m.weight_quantizer.update_observer(m.weight)
+                m.weight_quantizer.calc_qparams()

--- a/sparsebit/quantization/tools/errors_profiler.py
+++ b/sparsebit/quantization/tools/errors_profiler.py
@@ -1,4 +1,3 @@
-from operator import mod
 from typing import Callable
 from functools import partial
 import torch

--- a/sparsebit/quantization/tools/errors_profiler.py
+++ b/sparsebit/quantization/tools/errors_profiler.py
@@ -5,7 +5,7 @@ import torch.fx as fx
 import torch.nn.functional as F
 
 from .tensor_wrapper import to_detach
-from .graph_wrapper import GraphVisisor, SharedData
+from .graph_wrapper import GraphVisitor, SharedData
 
 
 class QuantizationErrorProfiler(object):
@@ -71,7 +71,7 @@ class QuantizationErrorProfiler(object):
             )
             return handles
 
-        builder = GraphVisisor(self.model, hook_wrapper)
+        builder = GraphVisitor(self.model, hook_wrapper)
 
         self.model.forward(data)
 
@@ -126,7 +126,7 @@ class QuantizationErrorProfiler(object):
                 )
             return handles
 
-        builder = GraphVisisor(self.model, hook_wrapper)
+        builder = GraphVisitor(self.model, hook_wrapper)
 
         self.model.forward(data)
 

--- a/sparsebit/quantization/tools/graph_wrapper.py
+++ b/sparsebit/quantization/tools/graph_wrapper.py
@@ -1,3 +1,5 @@
+from typing import Callable
+import torch
 import torch.fx as fx
 
 
@@ -5,3 +7,112 @@ def fx_symbolic_trace(model):
     if not getattr(model, "graph", None):
         model = fx.symbolic_trace(model)
     return model
+
+
+class SharedData(object):
+    """用于管理中间结果。"""
+
+    def __init__(self):
+        self.values = {}
+        self.edges = {}
+        self.output_degrees = {}
+        self.outputs = {}
+
+    def __del__(self):
+        assert len(self.output_degrees) == 0
+        assert len(self.outputs) == 0
+        assert len(self.values) == 0, "use extract_value to get out all the results"
+
+    def add_node(self, name: str, inputs: list):
+        self.output_degrees[name] = 0
+        self.edges[name] = [i for i in inputs if i is not None]
+        for inp in self.edges[name]:
+            if inp not in self.output_degrees:
+                self.output_degrees[inp] = 1
+            else:
+                self.output_degrees[inp] += 1
+
+    def finish_node(self, name):
+        for inp in self.edges[name]:
+            self.output_degrees[inp] -= 1
+            if self.output_degrees[inp] == 0:
+                del self.output_degrees[inp]
+                self.outputs.pop(inp, None)
+        if self.output_degrees[name] == 0:
+            del self.output_degrees[name]
+            self.outputs.pop(name, None)
+
+    def set_output(self, name: str, value):
+        self.outputs[name] = value
+
+    def set_value(self, name: str, value_name: str, value):
+        assert value_name != "output"
+        if value_name not in self.values:
+            self.values[value_name] = {}
+        self.values[value_name][name] = value
+
+    def get_output(self, name: str):
+        return self.outputs.get(name, None)
+
+    def get_value(self, name: str, value_name: str):
+        assert value_name != "output"
+        if value_name not in self.values or name not in self.values[value_name]:
+            return None
+        return self.values[value_name][name]
+
+    def extract_node_args(self, args, real_input: tuple = None, batch: int = None):
+        # usage: extract_node_args(node.args, x_in) in forward_hook
+        if isinstance(args, fx.Node):
+            input = self.get_output(args.target)
+            if not isinstance(input, torch.Tensor) and not input:
+                input = real_input
+            return input[batch] if batch is not None else input
+
+        if isinstance(args, (list, tuple)):
+            inputs = [
+                self.extract_node_args(i, j, batch=batch)
+                for i, j in zip(args, real_input if real_input else [None] * len(args))
+            ]
+            if isinstance(args, tuple):
+                inputs = tuple(inputs)
+            return inputs
+
+        return args
+
+    def extract_value(self, value_name: str):
+        return self.values.pop(value_name, {})
+
+
+class GraphVisisor(object):
+    def __init__(self, model: fx.GraphModule, hook_wrapper: Callable):
+        self.storage = SharedData()
+        self.build(model, hook_wrapper)
+
+    def __del__(self):
+        for handle in self.handles:
+            handle.remove()
+
+    def build(self, model: fx.GraphModule, hook_wrapper: Callable):
+        fx_graph = model.graph
+        named_modules = dict(model.named_modules())
+
+        self.handles = []
+        # assume fx_graph.node is topological-sorted
+        for node in fx_graph.nodes:
+            if node.op in ["placeholder", "output"]:  # skip IO empty node
+                continue
+            node_name = node.target
+            module = named_modules[node_name]
+
+            input_node_names = [
+                input_node.target for input_node in node.all_input_nodes
+            ]
+            self.storage.add_node(node_name, input_node_names)
+
+            ret = hook_wrapper(
+                node=node,
+                module=module,
+                storage=self.storage,
+            )
+            if ret is not None:
+                self.handles.extend(ret)

--- a/sparsebit/quantization/tools/graph_wrapper.py
+++ b/sparsebit/quantization/tools/graph_wrapper.py
@@ -102,7 +102,10 @@ class GraphVisisor(object):
             if node.op in ["placeholder", "output"]:  # skip IO empty node
                 continue
             node_name = node.target
-            module = named_modules[node_name]
+            if node.op == "get_attr":  # use model.xxx to get constant nn.Parameter
+                module = getattr(model, node.target)
+            else:
+                module = named_modules[node_name]
 
             input_node_names = [
                 input_node.target for input_node in node.all_input_nodes

--- a/sparsebit/quantization/tools/graph_wrapper.py
+++ b/sparsebit/quantization/tools/graph_wrapper.py
@@ -83,7 +83,7 @@ class SharedData(object):
         return self.values.pop(value_name, {})
 
 
-class GraphVisisor(object):
+class GraphVisitor(object):
     def __init__(self, model: fx.GraphModule, hook_wrapper: Callable):
         self.storage = SharedData()
         self.build(model, hook_wrapper)
@@ -101,16 +101,15 @@ class GraphVisisor(object):
         for node in fx_graph.nodes:
             if node.op in ["placeholder", "output"]:  # skip IO empty node
                 continue
-            node_name = node.target
             if node.op == "get_attr":  # use model.xxx to get constant nn.Parameter
                 module = getattr(model, node.target)
             else:
-                module = named_modules[node_name]
+                module = named_modules[node.target]
 
-            input_node_names = [
+            input_node_targets = [
                 input_node.target for input_node in node.all_input_nodes
             ]
-            self.storage.add_node(node_name, input_node_names)
+            self.storage.add_node(node.target, input_node_targets)
 
             ret = hook_wrapper(
                 node=node,

--- a/sparsebit/quantization/tools/tensor_wrapper.py
+++ b/sparsebit/quantization/tools/tensor_wrapper.py
@@ -1,0 +1,37 @@
+import torch
+
+
+def to_cpu(x):
+    if isinstance(x, torch.Tensor):
+        return x.cpu()
+    if isinstance(x, tuple):
+        return tuple([to_cpu(i) for i in x])
+    if isinstance(x, list):
+        return [to_cpu(i) for i in x]
+    if isinstance(x, dict):
+        return {k: to_cpu(v) for k, v in x.items()}
+    return x
+
+
+def to_device(x, device):
+    if isinstance(x, torch.Tensor):
+        return x.to(device)
+    if isinstance(x, tuple):
+        return tuple([to_device(i, device) for i in x])
+    if isinstance(x, list):
+        return [to_device(i, device) for i in x]
+    if isinstance(x, dict):
+        return {k: to_device(v, device) for k, v in x.items()}
+    return x
+
+
+def to_detach(x):
+    if isinstance(x, torch.Tensor):
+        return x.detach()
+    if isinstance(x, tuple):
+        return tuple([to_detach(i) for i in x])
+    if isinstance(x, list):
+        return [to_detach(i) for i in x]
+    if isinstance(x, dict):
+        return {k: to_detach(v) for k, v in x.items()}
+    return x


### PR DESCRIPTION
- Restructure the calibration part, add more stringent graph traversal cache restrictions, and increase *getattr* processing.

- Calibration supports multiple-input operators.

- Use *all_input_nodes* instead of *args* in *torch.fx.node* to get inputs. Using args leads to missing topology info.