### PR TITLE
add adaRound

### DIFF
--- a/ci/regular_tests/test_calibration.py
+++ b/ci/regular_tests/test_calibration.py
@@ -1,0 +1,96 @@
+import copy
+import torch
+import torch.nn as nn
+import torchvision.models as models
+
+from sparsebit.quantization.quant_model import QuantModel
+from sparsebit.quantization.quant_config import _C as default_config
+
+
+def build_qconfig(changes_list):
+    new_config = default_config.clone()
+    new_config.defrost()
+    new_config.DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+    new_config.merge_from_list(changes_list)
+    new_config.freeze()
+    return new_config
+
+
+def normal_calibration(model, inputs, config):
+    qmodel = QuantModel(model, config)
+    qmodel.prepare_calibration()
+    qmodel.eval()
+    # run calibration
+    with torch.no_grad():
+        if torch.cuda.is_available():
+            inputs = inputs.cuda()
+        output = qmodel(inputs)
+    qmodel.calc_qparams()
+    print("finish normal calibration")
+
+
+def asym_calibration_wquant(model, inputs, config):
+    qmodel = QuantModel(model, config)
+    qmodel.prepare_calibration()
+    qmodel.eval()
+    # run calibration
+    with torch.no_grad():
+        if torch.cuda.is_available():
+            inputs = inputs.cuda()
+        output = qmodel(inputs)
+    qmodel.calc_qparams(asym=True, w_quant=True, a_quant=False)
+    print("finish asym calibration with w_quant")
+
+
+def asym_calibration_aquant(model, inputs, config):
+    qmodel = QuantModel(model, config)
+    qmodel.prepare_calibration()
+    qmodel.eval()
+    # run calibration
+    with torch.no_grad():
+        if torch.cuda.is_available():
+            inputs = inputs.cuda()
+        output = qmodel(inputs)
+    qmodel.calc_qparams(asym=True, w_quant=False, a_quant=True)
+    print("finish asym calibration with a_quant")
+
+
+def asym_calibration_waquant(model, inputs, config):
+    qmodel = QuantModel(model, config)
+    qmodel.prepare_calibration()
+    qmodel.eval()
+    # run calibration
+    with torch.no_grad():
+        if torch.cuda.is_available():
+            inputs = inputs.cuda()
+        output = qmodel(inputs)
+    qmodel.calc_qparams(asym=True, w_quant=True, a_quant=True)
+    print("finish asym calibration with wa_quant")
+
+
+def test_calibration():
+    qconfig = [
+        ("BACKEND", "tensorrt"),
+        ("SCHEDULE.FUSE_BN", True),
+        ("W.QSCHEME", "per-channel-symmetric"),
+        ("W.QUANTIZER.TYPE", "uniform"),
+        ("W.QUANTIZER.BIT", 8),
+        ("W.OBSERVER.TYPE", "MINMAX"),
+        ("A.QSCHEME", "per-tensor-symmetric"),
+        ("A.QUANTIZER.TYPE", "uniform"),
+        ("A.QUANTIZER.BIT", 8),
+        ("A.OBSERVER.TYPE", "MINMAX"),
+        ("A.OBSERVER.LAYOUT", "NCHW"),
+    ]
+    qconfig = [j for i in qconfig for j in i]
+    qconfig = build_qconfig(qconfig)
+    model = models.__dict__["resnet18"](pretrained=False)
+    rand_inputs = torch.randn(4, 3, 224, 224)
+    normal_calibration(model, rand_inputs, qconfig)
+    asym_calibration_wquant(model, rand_inputs, qconfig)
+    asym_calibration_aquant(model, rand_inputs, qconfig)
+    asym_calibration_waquant(model, rand_inputs, qconfig)
+
+
+if __name__ == "__main__":
+    test_calibration()

--- a/sparsebit/quantization/quant_model.py
+++ b/sparsebit/quantization/quant_model.py
@@ -190,8 +190,7 @@ class QuantModel(nn.Module):
 
     def calc_qparams(self):
         assert hasattr(self, "calibration_runner"), "run self.prepare_calibration first"
-        self.calibration_runner.feature_layerwise_calibration(self.device)
-        self.calibration_runner.weight_calibration()
+        self.calibration_runner.layerwise_calibration(self.device)
         del self.calibration_runner
 
     def init_QAT(self):

--- a/sparsebit/quantization/quant_model.py
+++ b/sparsebit/quantization/quant_model.py
@@ -188,9 +188,12 @@ class QuantModel(nn.Module):
         self.calibration_runner = CalibrationRunner(self.model)
         self.calibration_runner.prepare_calibration()
 
-    def calc_qparams(self):
+    def calc_qparams(self, asym=False, w_quant=False, a_quant=False):
+        """
+        asym: enable calculate the quant params with all preceding layers quantized
+        """
         assert hasattr(self, "calibration_runner"), "run self.prepare_calibration first"
-        self.calibration_runner.layerwise_calibration(self.device)
+        self.calibration_runner.layerwise_calibration(self.device, asym, w_quant, a_quant)
         del self.calibration_runner
 
     def init_QAT(self):

--- a/sparsebit/quantization/quant_model.py
+++ b/sparsebit/quantization/quant_model.py
@@ -193,7 +193,9 @@ class QuantModel(nn.Module):
         asym: enable calculate the quant params with all preceding layers quantized
         """
         assert hasattr(self, "calibration_runner"), "run self.prepare_calibration first"
-        self.calibration_runner.layerwise_calibration(self.device, asym, w_quant, a_quant)
+        self.calibration_runner.layerwise_calibration(
+            self.device, asym, w_quant, a_quant
+        )
         del self.calibration_runner
 
     def init_QAT(self):

--- a/sparsebit/quantization/quantizers/__init__.py
+++ b/sparsebit/quantization/quantizers/__init__.py
@@ -12,6 +12,7 @@ from . import lsq
 from . import dorefa
 from . import lsq_plus
 from . import pact
+from . import adaround
 
 
 def build_quantizer(cfg):

--- a/sparsebit/quantization/quantizers/adaround.py
+++ b/sparsebit/quantization/quantizers/adaround.py
@@ -1,0 +1,95 @@
+import torch
+import torch.nn as nn
+import numpy as np
+from sparsebit.quantization.quantizers import Quantizer as BaseQuantizer
+from sparsebit.quantization.quantizers import register_quantizer
+from sparsebit.quantization.common import QuantTarget
+from .quant_tensor import STE
+
+
+@register_quantizer
+class Quantizer(BaseQuantizer):
+    TYPE = "adaround"
+
+    def __init__(self, config):
+        super(Quantizer, self).__init__(config)
+        assert config.TARGET[0] == QuantTarget.WEIGHT, "AdaRound only supports to quant weights"
+        self.zeta, self.gamma = 1.1, -0.1 # stretch-parameters
+
+    def init_variables(self, x):
+        x_floor = torch.floor(x / self.scale)
+        rest = (x / self.scale) - x_floor
+        v = -torch.log((self.zeta - self.gamma) / (rest - self.gamma) - 1) # => rectified_sigmoid(v)=rest
+        self.v = nn.Parameter(v.to(x.device))
+
+    def _get_soft_round_values(self):
+        return torch.clamp(torch.sigmoid(self.v) * (self.zeta - self.gamma) + self.gamma, 0, 1)
+
+    def _forward(self, x, scale, zero_point):
+        x_floor = torch.floor(x / scale)
+        if self.training:
+            x_q = x_floor + self._get_soft_round_values()
+        else: # evaluation
+            x_q = x_floor + (self.v>=0).float()
+        x_dq = STE.apply(x_q, torch.ones_like(scale), zero_point, self.qdesc, self.backend) * scale
+        return x_dq
+
+
+def reconstruct_qlayer(layer, inputs: torch.Tensor, outputs: torch.Tensor,
+                       batch_size=32, max_steps=2000, beta_range=(20, 2),
+                       warmup=0.0, p=2.0, round_loss_weight=1e-3):
+    # init
+    layer.set_quant(w_quant=True, a_quant=False)
+    layer.weight_quantizer.init_variables(layer.weight)
+    layer.weight_quantizer.train()
+    opt_params = [layer.weight_quantizer.v]
+    optimizer = torch.optim.Adam(opt_params)
+    beta_decayer = LinearTempDecay(max_steps=max_steps, rel_start_step=warmup,
+                                   start_beta=beta_range[0], end_beta=beta_range[1])
+    loss_start_step = int(warmup * max_steps)
+    print_freq = 1
+    # training
+    device = layer.weight.device
+    for step in range(max_steps):
+        idx = torch.randperm(inputs.size(0))[:batch_size]
+        cur_input, cur_output = inputs[idx].to(device), outputs[idx].to(device)
+        optimizer.zero_grad()
+        quant_output = layer(cur_input)
+        # calculate reconstruct_loss
+        rec_loss = (quant_output - cur_output).abs().pow(p).sum(1).mean()
+        # calculate round loss
+        if step < loss_start_step:
+            beta = round_loss = 0
+        else:
+            beta = beta_decayer(step)
+            round_vals = layer.weight_quantizer._get_soft_round_values()
+            round_loss = (1 - ((round_vals - .5).abs() * 2).pow(beta)).sum()
+        loss = rec_loss + round_loss_weight * round_loss
+        loss.backward()
+        optimizer.step()
+        if step % print_freq == 0:
+            print('Loss: {:.3f} (rec: {:.3f}, round: {:.3f}) beta={:.2f} step={}'.format(loss, rec_loss, round_loss, beta, step))
+    torch.cuda.empty_cache()
+    layer.weight_quantizer.eval()
+
+
+class LinearTempDecay:
+    def __init__(self, max_steps, rel_start_step=0.2, start_beta=10, end_beta=2):
+        self.max_steps = max_steps
+        self.start_step = int(rel_start_step * max_steps)
+        self.start_beta = start_beta
+        self.end_beta = end_beta
+
+    def __call__(self, step):
+        """
+        Cosine annealing scheduler for temperature b.
+        :param t: the current time step
+        :return: scheduled temperature
+        """
+        if step < self.start_step:
+            return self.start_beta
+        else:
+            ratio = (step - self.start_step) / (self.max_steps - self.start_step)
+            beta = (self.end_beta + (self.start_beta - self.end_beta) * max(0., (1-ratio)))
+            return beta
+

--- a/sparsebit/quantization/tools/calibration.py
+++ b/sparsebit/quantization/tools/calibration.py
@@ -91,7 +91,9 @@ class CalibrationRunner(object):
             self.run_weight_calibration(node, asym, a_quant=a_quant)
             # foward quant output
             if asym:
-                quant_outputs = self.module_forward(batch_num, node, device, asym, w_quant, a_quant)
+                quant_outputs = self.module_forward(
+                    batch_num, node, device, asym, w_quant, a_quant
+                )
                 self.builder.qstorage.set_output(node.target, quant_outputs)
                 self.builder.qstorage.finish_node(node.target)
             # pop the outputs of nodes whose out-degree=0
@@ -115,13 +117,24 @@ class CalibrationRunner(object):
             module.weight_quantizer.update_observer(module.weight)
             module.weight_quantizer.calc_qparams()
             if module.weight_quantizer.TYPE.lower() == "adaround":
-                assert len(node.all_input_nodes) == 1, "AdaRound not supports the oprs which has more than one inputs"
-                inp_tensors = self.builder.storage.get_output(node.all_input_nodes[0].target)
+                assert (
+                    len(node.all_input_nodes) == 1
+                ), "AdaRound not supports the oprs which has more than one inputs"
+                inp_tensors = self.builder.storage.get_output(
+                    node.all_input_nodes[0].target
+                )
                 out_tensors = self.builder.storage.get_output(node.target)
                 print("Reconstruct {}".format(node.target))
-                reconstruct_qlayer(module, torch.cat(inp_tensors, dim=0), torch.cat(out_tensors, dim=0), a_quant=a_quant)
+                reconstruct_qlayer(
+                    module,
+                    torch.cat(inp_tensors, dim=0),
+                    torch.cat(out_tensors, dim=0),
+                    a_quant=a_quant,
+                )
 
-    def module_forward(self, batch_num, node, device, asym=False, w_quant=False, a_quant=False):
+    def module_forward(
+        self, batch_num, node, device, asym=False, w_quant=False, a_quant=False
+    ):
         module = getattr(self.model, node.target)
         module.eval()
         if isinstance(module, QuantOpr) and asym:

--- a/sparsebit/quantization/tools/calibration.py
+++ b/sparsebit/quantization/tools/calibration.py
@@ -1,3 +1,4 @@
+import copy
 import torch
 from functools import partial
 
@@ -62,66 +63,82 @@ class CalibrationRunner(object):
 
         self.builder = GraphVisitor(self.model, hook_wrapper)
 
-    def layerwise_calibration(self, device):
+    def layerwise_calibration(self, device, asym=False, w_quant=False, a_quant=False):
+        """
+        asym: enable calibration with all preceding layers quantized
+        w_quant: quant the weights in all preceding layers
+        a_quant: quant the inputs in all preceding layers
+        """
         # manual forward once to calculate calibration
         assert hasattr(self, "builder"), "run self.prepare_calibration first!"
-        batch_num = None
         # remove hook from module before calibration
         for handle in self.builder.handles:
             handle.remove()
+        if asym:
+            self.builder.qstorage = copy.deepcopy(self.builder.storage)
         # run calibration qopr-by-qopr
+        batch_num = None
         for node in self.model.graph.nodes:
             if node.op in ["placeholder", "output"]:
                 if batch_num is None:
                     batch_num = len(self.builder.storage.get_output(node.target))
                 continue
-
             assert batch_num is not None
-
-            module = getattr(self.model, node.target)
-            if isinstance(module, QuantOpr) and getattr(
-                module, "input_quantizer", None
-            ):
-                for inp_node in node.all_input_nodes:
-                    inp_tensors = self.builder.storage.get_output(inp_node.target)
-                    for inp_tensor in inp_tensors:
-                        if isinstance(inp_tensor, torch.Tensor):
-                            module.input_quantizer.update_observer(inp_tensor)
-                module.input_quantizer.calc_qparams()
-                module.input_quantizer.observer.data_cache.reset()
-
-            with torch.no_grad():
-                outputs = []
-                for batch_idx in range(batch_num):
-                    if node.op == "get_attr":  # is constant value
-                        outputs.append(to_cpu(module.data))
-                        continue
-                    args = self.builder.storage.extract_node_args(
-                        node.args, batch=batch_idx
-                    )
-                    args = to_device(args, device)
-                    kwargs = self.builder.storage.extract_node_kwargs(
-                        node.kwargs, batch=batch_idx
-                    )
-                    kwargs = to_device(kwargs, device)
-                    # more time for less cuda memory occupation
-                    outputs.append(to_cpu(module(*args, **kwargs)))
-            # save outputs of this node into storage
-            self.builder.storage.set_output(node.target, outputs)
-            # weight calibration
-            if isinstance(module, QuantOpr) and getattr(module, "weight_quantizer", None):
-                module.weight_quantizer.update_observer(module.weight)
-                module.weight_quantizer.calc_qparams()
-                if module.weight_quantizer.TYPE.lower() == "adaround":
-                    assert len(node.all_input_nodes) == 1, "AdaRound not supports the oprs which has more than one inputs"
-                    inp_tensors = self.builder.storage.get_output(node.all_input_nodes[0].target)
-                    out_tensors = self.builder.storage.get_output(node.target)
-                    reconstruct_qlayer(module, torch.cat(inp_tensors, dim=0), torch.cat(out_tensors, dim=0))
+            self.run_feature_calibration(node, asym)
+            # forward float output
+            float_outputs = self.module_forward(batch_num, node, device)
+            self.builder.storage.set_output(node.target, float_outputs)
+            self.run_weight_calibration(node, asym, a_quant=a_quant)
+            # foward quant output
+            if asym:
+                quant_outputs = self.module_forward(batch_num, node, device, asym, w_quant, a_quant)
+                self.builder.qstorage.set_output(node.target, quant_outputs)
+                self.builder.qstorage.finish_node(node.target)
             # pop the outputs of nodes whose out-degree=0
             self.builder.storage.finish_node(node.target)
 
-    def weight_calibration(self):
-        for n, m in self.model.named_modules():
-            if isinstance(m, QuantOpr) and getattr(m, "weight_quantizer", None):
-                m.weight_quantizer.update_observer(m.weight)
-                m.weight_quantizer.calc_qparams()
+    def run_feature_calibration(self, node, asym=False):
+        module = getattr(self.model, node.target)
+        if isinstance(module, QuantOpr) and getattr(module, "input_quantizer", None):
+            for inp_node in node.all_input_nodes:
+                _storage = self.builder.qstorage if asym else self.builder.storage
+                inp_tensors = _storage.get_output(inp_node.target)
+                for inp_tensor in inp_tensors:
+                    if isinstance(inp_tensor, torch.Tensor):
+                        module.input_quantizer.update_observer(inp_tensor)
+            module.input_quantizer.calc_qparams()
+            module.input_quantizer.observer.data_cache.reset()
+
+    def run_weight_calibration(self, node, asym=False, a_quant=False):
+        module = getattr(self.model, node.target)
+        if isinstance(module, QuantOpr) and getattr(module, "weight_quantizer", None):
+            module.weight_quantizer.update_observer(module.weight)
+            module.weight_quantizer.calc_qparams()
+            if module.weight_quantizer.TYPE.lower() == "adaround":
+                assert len(node.all_input_nodes) == 1, "AdaRound not supports the oprs which has more than one inputs"
+                inp_tensors = self.builder.storage.get_output(node.all_input_nodes[0].target)
+                out_tensors = self.builder.storage.get_output(node.target)
+                print("Reconstruct {}".format(node.target))
+                reconstruct_qlayer(module, torch.cat(inp_tensors, dim=0), torch.cat(out_tensors, dim=0), a_quant=a_quant)
+
+    def module_forward(self, batch_num, node, device, asym=False, w_quant=False, a_quant=False):
+        module = getattr(self.model, node.target)
+        module.eval()
+        if isinstance(module, QuantOpr) and asym:
+            module.set_quant(w_quant, a_quant)
+        with torch.no_grad():
+            outputs = []
+            for batch_idx in range(batch_num):
+                if node.op == "get_attr":  # is constant value
+                    outputs.append(to_cpu(module.data))
+                    continue
+                storage = self.builder.qstorage if asym else self.builder.storage
+                args = storage.extract_node_args(node.args, batch=batch_idx)
+                kwargs = storage.extract_node_kwargs(node.kwargs, batch=batch_idx)
+                args = to_device(args, device)
+                kwargs = to_device(kwargs, device)
+                # more time for less cuda memory occupation
+                outputs.append(to_cpu(module(*args, **kwargs)))
+        if isinstance(module, QuantOpr):
+            module.set_quant(w_quant=False, a_quant=False)
+        return outputs

--- a/sparsebit/quantization/tools/calibration.py
+++ b/sparsebit/quantization/tools/calibration.py
@@ -103,8 +103,7 @@ class CalibrationRunner(object):
         module = getattr(self.model, node.target)
         if isinstance(module, QuantOpr) and getattr(module, "input_quantizer", None):
             for inp_node in node.all_input_nodes:
-                _storage = self.builder.qstorage if asym else self.builder.storage
-                inp_tensors = _storage.get_output(inp_node.target)
+                inp_tensors = self.builder.storage.get_output(inp_node.target)
                 for inp_tensor in inp_tensors:
                     if isinstance(inp_tensor, torch.Tensor):
                         module.input_quantizer.update_observer(inp_tensor)
@@ -120,9 +119,8 @@ class CalibrationRunner(object):
                 assert (
                     len(node.all_input_nodes) == 1
                 ), "AdaRound not supports the oprs which has more than one inputs"
-                inp_tensors = self.builder.storage.get_output(
-                    node.all_input_nodes[0].target
-                )
+                _storage = self.builder.qstorage if asym else self.builder.storage
+                inp_tensors = _storage.get_output(node.all_input_nodes[0].target)
                 out_tensors = self.builder.storage.get_output(node.target)
                 print("Reconstruct {}".format(node.target))
                 reconstruct_qlayer(

--- a/sparsebit/quantization/tools/graph_wrapper.py
+++ b/sparsebit/quantization/tools/graph_wrapper.py
@@ -114,6 +114,7 @@ class SharedData(object):
 class GraphVisitor(object):
     def __init__(self, model: fx.GraphModule, hook_wrapper: Callable):
         self.storage = SharedData()
+        self.qstorage = None
         self.build(model, hook_wrapper)
 
     def __del__(self):


### PR DESCRIPTION
### A Comparison between the reproduction of AdaRound in Sparsebit with papers
- model arch: resnet18
- datasets: ImageNet-1k
- calibration-size: 1024 
- bits: 4wfa(4bit weight, float activation)
- default qconfig: pertensor, observer-mse

#### Table4: 
- The influence on the ImageNet validation accuracy (%) for Resnet18, by incorporating asymmetric reconstruction MSE loss and activation function in the rounding optimization objective
 
  optimization | bits | top-1(paper) | top-1(ours)
  --- | --- | --- | --- 
  Layerwise | 4wfa | 66.56 | 66.516
  Asymmetric | 4wfa | 68.37 | 68.374

#### Table6:
- Comparison between various quantization grids in combination with rounding-to-nearest and AdaRound. We report ImageNet validation accuracy (%) for Resnet18.

  Grid | Nearest(paper / ours)  | AdaRound(paper / ours)
  --- | --- | --- 
  min-max | 0.23 / 0.246 |  61.96 /  61.00
  MSE | 23.99 / 20.460 |   68.60 / 68.37

#### Table

r18 | bits | top-1 / top-5
--- | --- | --- | 
Nearest_perchannel_mse | 4w8a | 53.800 / 78.180
AdaRound_perchannel_mse_asym_waquant | 4w8a | 68.674 / 88.558
 