### PR TITLE
Hotfix: fp16 + fp32 error

### DIFF
--- a/large_language_models/llama/quantization/utils/gptq.py
+++ b/large_language_models/llama/quantization/utils/gptq.py
@@ -157,6 +157,7 @@ class GPTQ:
                 self.layer.bias.data += delta_bias
             else:
                 self.layer.bias = nn.Parameter(delta_bias)
+        self.layer.bias.data = self.layer.bias.data.to(torch.half)
         self.layer.weight.data = Q
 
         if DEBUG:


### PR DESCRIPTION
Fix a bug in llama convert code, with an add between fp16 and fp32