### PR TITLE
Update README.md: Add Huggingface repo for 7B and 13B quantization

### DIFF
--- a/large_language_models/alpaca-qlora/requirements.txt
+++ b/large_language_models/alpaca-qlora/requirements.txt
@@ -3,6 +3,6 @@ loralib
 sentencepiece
 git+https://github.com/huggingface/transformers.git
 accelerate
-bitsandbytes
-git+https://github.com/huggingface/peft.git
+bitsandbytes==0.37.2
+peft==0.2.0
 gradio

--- a/large_language_models/llama/quantization/README.md
+++ b/large_language_models/llama/quantization/README.md
@@ -1,4 +1,5 @@
 ### Update News
+- LLaMA-7B and 13B quantization are also available [here](https://huggingface.co/cnbeining/sparsebit-llama-quantization-7b-13b).
 - We have updated a llama-13b checkpoint with 3-bit 128-group quantization [here](https://drive.google.com/file/d/1LjZmOU8tr2VT6HdAP_WbuX8cqmrs5DrR). For config_cache and tokenizer_cache, the files can be found [here in huggingface](https://huggingface.co/decapoda-research/llama-13b-hf).
 - We implemented a cuda kernel for groupsize=128(int3/int4) & groupsize=64(int2). In our experiments, setting groupsize=128(int3) can make all quantization models achieve a significant increase in ppl compared to groupsize=-1. All results are updated in Table A.
 - We add `--single_device_mode` to support all quant models run in a single GPU(i.e. 2080ti). Please refer to the inference section for details.


### PR DESCRIPTION
As title.

Large file shared with Google Drive can be hard to download even with help of [gdown](https://github.com/wkentaro/gdown/issues/43) - making a backup  on Huggingface.