### PR TITLE
fix zero point parameter round

### DIFF
--- a/sparsebit/quantization/quantizers/base.py
+++ b/sparsebit/quantization/quantizers/base.py
@@ -89,7 +89,7 @@ class Quantizer(nn.Module, abc.ABC):
     def enable_export_onnx(self):
         self.export_onnx = True
         # round zero point for onnx export
-        self.zero_point = self.zero_point.round()
+        self.zero_point.data = self.zero_point.data.round()
 
     def disable_export_onnx(self):
         self.export_onnx = False


### PR DESCRIPTION
`self.zero_point` may be an instance of `torch.Tensor` or `torch.nn.Parameter`. When it is the latter, the original code will report an error. The modified code is compatible with both situations.